### PR TITLE
Only admins can add new users

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -1,39 +1,74 @@
-import User from '../models/User';
+import User, { IUser } from '../models/User';
 import { Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { jwtPayload } from '../middleware/authentication';
-import { BadRequestError, UnauthenticatedError } from '../errors';
+import {
+  BadRequestError,
+  UnauthenticatedError,
+  UnauthorizedError,
+} from '../errors';
 import {
   ACCESS_TOKEN_EXPIRATION,
   ACCESS_TOKEN_SECRET,
   REFRESH_TOKEN_SECRET,
 } from '../config';
+import getRandomPassword from '../utils/getRandomPassword';
+import { Document } from 'mongoose';
 
 const register = async (req: Request, res: Response) => {
-  const { name, email, password } = req.body;
-  if (!name || !email || !password) {
-    throw new BadRequestError('Missing credentials');
+  const users: IUser[] = req.body.users;
+  const cohort = req.body.cohort;
+
+  // checks if user can register other users
+  const user = await User.findById(req.user.userId);
+  if (!user) {
+    throw new UnauthenticatedError('Invalid credentials');
   }
-  const user = await User.create({ name, email, password });
+  if (user.role !== 'admin') {
+    throw new UnauthorizedError(
+      'Your current role does not allow you to add new users'
+    );
+  }
 
-  const token = user.createJWT();
-  const refreshToken = user.createRefreshToken();
-
-  await user.updateOne({ refreshToken });
-
-  res.cookie('token', token, {
-    httpOnly: true,
-    sameSite: 'none',
-    secure: true,
-    maxAge: 24 * 60 * 60 * 1000,
+  // saves all users from the req
+  const newUserPromises = users.map(async (u) => {
+    const password = getRandomPassword();
+    if (!u.name || !u.email) {
+      return Promise.reject(
+        `Could not save ${JSON.stringify(u)}: Missing credentials`
+      );
+    }
+    // maybe the user is already register in another cohort
+    const user = await User.findOne({ email: u.email });
+    if (user) {
+      if (user.cohorts.includes(cohort)) {
+        return Promise.reject(`${user.email} already in this cohort`);
+      }
+      return User.findByIdAndUpdate(user._id, {
+        cohorts: user.cohorts.concat(cohort),
+      });
+    }
+    return User.create({
+      name: u.name,
+      email: u.email,
+      password,
+      cohorts: [cohort],
+    });
   });
 
-  return res
-    .status(201)
-    .json({
-      user: { name: user.name, userId: user._id, email: user.email },
-      token,
-    });
+  const savedUsers = await Promise.allSettled(newUserPromises);
+  const newUsers: Document<IUser>[] = [];
+  const errors: PromiseRejectedResult[] = [];
+  savedUsers.forEach((u) => {
+    if (u.status === 'fulfilled') {
+      newUsers.push(u.value!);
+    }
+    if (u.status === 'rejected') {
+      errors.push(u.reason);
+    }
+  });
+
+  res.status(201).json({ users: newUsers, errors, count: newUsers.length });
 };
 
 const login = async (req: Request, res: Response) => {
@@ -63,12 +98,10 @@ const login = async (req: Request, res: Response) => {
     maxAge: 24 * 60 * 60 * 1000,
   });
 
-  return res
-    .status(200)
-    .json({
-      user: { name: user.name, userId: user._id, email: user.email },
-      token,
-    });
+  return res.status(200).json({
+    user: { name: user.name, userId: user._id, email: user.email },
+    token,
+  });
 };
 
 const refreshToken = async (req: Request, res: Response) => {
@@ -93,12 +126,10 @@ const refreshToken = async (req: Request, res: Response) => {
     expiresIn: ACCESS_TOKEN_EXPIRATION,
   });
 
-  return res
-    .status(200)
-    .json({
-      user: { name: user.name, userId: user._id, email: user.email },
-      token,
-    });
+  return res.status(200).json({
+    user: { name: user.name, userId: user._id, email: user.email },
+    token,
+  });
 };
 
 const logout = async (req: Request, res: Response) => {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,4 +1,4 @@
-import mongoose, { Document } from 'mongoose';
+import mongoose, { Document, Mongoose, Schema } from 'mongoose';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import {
@@ -7,11 +7,14 @@ import {
   REFRESH_TOKEN_EXPIRATION,
   REFRESH_TOKEN_SECRET,
 } from '../config';
+import Cohort from './Cohort';
 
 export interface IUser extends Document {
   name: string;
   email: string;
   password: string;
+  role: 'admin' | 'student' | 'student-leader' | 'mentor';
+  cohorts: Array<string>;
   refreshToken?: string;
   createJWT: () => string;
   createRefreshToken: () => string;
@@ -43,6 +46,17 @@ const UserSchema = new mongoose.Schema<IUser>(
     refreshToken: {
       type: String,
     },
+    role: {
+      type: String,
+      enum: ['admin', 'student', 'student-leader', 'mentor'],
+      default: 'student',
+    },
+    cohorts: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: Cohort,
+      },
+    ],
   },
   { timestamps: true }
 );

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,9 +1,10 @@
 import { login, logout, refreshToken, register } from '../controllers/auth';
 import express from 'express';
+import authMiddleware from '../middleware/authentication';
 
 const router = express.Router();
 
-router.post('/register', register);
+router.post('/register', authMiddleware, register);
 router.post('/login', login);
 router.get('/logout', logout);
 router.get('/refreshToken', refreshToken);

--- a/src/utils/getRandomPassword.ts
+++ b/src/utils/getRandomPassword.ts
@@ -1,0 +1,14 @@
+import crypto from 'node:crypto';
+
+function getRandomPassword(): string {
+  const chars =
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  let pwd = '';
+  while (pwd.length < 8) {
+    pwd += chars[crypto.randomInt(62)];
+  }
+
+  return pwd;
+}
+
+export default getRandomPassword;


### PR DESCRIPTION
Changes the register endpoint, so that only admins can add new users.

The function expects a list containing `{name, email}` of each user to be added and the ID of the cohort. A random password is assigned to each user.

This function still needs some work: each new user should receive an email notification that the account was created. Also, admins should be able to add users with other roles (currently all users are added with `role:'student'`). Both issues will be solved in the next PRs.