### PR TITLE
Updates user registration and refresh token

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -23,12 +23,6 @@ const register = async (req: Request, res: Response) => {
   const users: IUser[] = req.body.users;
   const cohortId = req.body.cohort;
 
-  // checks if user can register other users
-  const user = await User.findById(req.user.userId);
-  if (!user) {
-    throw new UnauthenticatedError('Invalid credentials');
-  }
-
   const cohort = await Cohort.findById(cohortId);
   if (!cohort) {
     throw new BadRequestError('This cohort does not exist');

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -187,9 +187,13 @@ const refreshToken = async (req: Request, res: Response) => {
     return res.sendStatus(403);
   }
 
-  const token = jwt.sign({ username: payload.name }, ACCESS_TOKEN_SECRET!, {
-    expiresIn: ACCESS_TOKEN_EXPIRATION,
-  });
+  const token = jwt.sign(
+    { name: payload.name, role: payload.role, userId: user._id },
+    ACCESS_TOKEN_SECRET!,
+    {
+      expiresIn: ACCESS_TOKEN_EXPIRATION,
+    }
+  );
 
   return res.status(200).json({
     user: {
@@ -225,7 +229,6 @@ const logout = async (req: Request, res: Response) => {
 const restrict = (...role: any) => {
   return (req: Request, res: Response, next: NextFunction) => {
     const userRoles = req.user.role;
-
     if (!userRoles.some((r) => role.includes(r))) {
       throw new UnauthenticatedError(
         'Your roles are not allowed to access this route'

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -77,6 +77,22 @@ const register = async (req: Request, res: Response) => {
   res.status(201).json({ users: newUsers, errors, count: newUsers.length });
 };
 
+const directRegister = async (req: Request, res: Response) => {
+  const { name, email, password, role } = req.body;
+
+  const user = await User.create({
+    name,
+    email,
+    password,
+    role,
+    isActivated: true,
+    confirmationCode: '111111',
+    cohorts: [],
+  });
+
+  res.status(201).json({ user });
+};
+
 const activateAccount = async (req: Request, res: Response) => {
   const { password, confirmationCode } = req.body;
   if (!confirmationCode || !password) {
@@ -209,4 +225,12 @@ const restrict = (...role: any) => {
   };
 };
 
-export { register, login, refreshToken, logout, restrict, activateAccount };
+export {
+  register,
+  login,
+  refreshToken,
+  logout,
+  restrict,
+  activateAccount,
+  directRegister,
+};

--- a/src/controllers/cohort.ts
+++ b/src/controllers/cohort.ts
@@ -15,7 +15,7 @@ const createCohort = async (req: Request, res: Response) => {
 };
 
 const getAllCohort = async (req: Request, res: Response) => {
-  const cohorts = await Cohort.find({});
+  const cohorts = await Cohort.find({}).populate('participants', '_id name');
 
   if (!cohorts) {
     return res

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -10,7 +10,6 @@ import {
 } from '../errors';
 
 const createSession = async (req: Request, res: Response) => {
-
   const { start, end, type, link, weekId } = req.body;
 
   if (!start || !end || !type || !link) {
@@ -65,9 +64,6 @@ const getSession = async (req: Request, res: Response) => {
     .populate(populateCreatorOptions)
     .populate(populateDiscussionOptions);
 
-
-
-
   if (!session) {
     throw new BadRequestError('This session does not exist');
   }
@@ -75,7 +71,6 @@ const getSession = async (req: Request, res: Response) => {
 };
 
 const updateSession = async (req: Request, res: Response) => {
-
   const {
     body: { start, end, type, link, userStatus },
   } = req;
@@ -88,7 +83,6 @@ const updateSession = async (req: Request, res: Response) => {
     );
   }
 
-
   const session = await Session.findOneAndUpdate(
     { _id: sessionId, creator: req.user.userId },
     req.body,
@@ -99,7 +93,6 @@ const updateSession = async (req: Request, res: Response) => {
   }
 
   return res.status(201).json({ session });
-
 };
 
 const deleteSession = async (req: Request, res: Response) => {

--- a/src/controllers/week.ts
+++ b/src/controllers/week.ts
@@ -5,7 +5,6 @@ import { Request, Response } from 'express';
 import { BadRequestError, UnauthenticatedError } from '../errors';
 import moment from 'moment-timezone';
 
-
 const createWeek = async (req: Request, res: Response) => {
   const { name, start, cohortId } = req.body;
   if (!name || !start) {
@@ -51,7 +50,6 @@ const getWeek = async (req: Request, res: Response) => {
   );
 
   if (!week) {
-
     throw new BadRequestError('This week does not exist');
   }
   res.status(200).json({ status: 'Success', week });
@@ -88,7 +86,6 @@ const deleteWeek = async (req: Request, res: Response) => {
 
   res.status(200).json({ status: 'Success! Week removed.' });
 };
-
 
 const currentWeek = async (req: Request, res: Response) => {
   const { cohortId, userTimeZone } = req.body;
@@ -133,4 +130,3 @@ function findCurrentWeek(userTimeZone: any, weeks: any) {
 }
 
 export { getAllWeek, getWeek, updateWeek, deleteWeek, createWeek, currentWeek };
-

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -95,7 +95,7 @@ UserSchema.methods.createJWT = function () {
 
 UserSchema.methods.createRefreshToken = function () {
   return jwt.sign(
-    { userId: this._id, name: this.name },
+    { userId: this._id, name: this.name, role: this.role },
     REFRESH_TOKEN_SECRET!,
     {
       expiresIn: REFRESH_TOKEN_EXPIRATION!,

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import {
   activateAccount,
+  directRegister,
   login,
   logout,
   refreshToken,
@@ -8,11 +9,11 @@ import {
 import express from 'express';
 import authMiddleware from '../middleware/authentication';
 import { restrict } from '../controllers/auth';
-import createHash from '../utils/hashPassword';
 
 const router = express.Router();
 
 router.post('/register', authMiddleware, restrict('admin'), register);
+router.post('/directRegister', directRegister);
 router.post('/login', login);
 router.get('/logout', logout);
 router.get('/refreshToken', refreshToken);

--- a/src/routes/cohort.ts
+++ b/src/routes/cohort.ts
@@ -10,7 +10,6 @@ import { restrict } from '../controllers/auth';
 
 const router = express.Router();
 
-
 router.route('/').get(getAllCohort).post(restrict('admin'), createCohort);
 router
   .route('/:cohortId')

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -14,12 +14,10 @@ import { restrict } from '../controllers/auth';
 
 const router = express.Router();
 
-
 router
   .route('/')
   .get(getAllSession)
   .post(restrict('mentor', 'student-leader'), createSession);
-
 
 router
   .route('/:sessionId')
@@ -29,7 +27,6 @@ router
 router
   .route('/:sessionId/student/updateStatus')
   .patch(restrict('student', 'student-leader'), updateStatus);
-
 
 router.route('/comment').get(getAllComment).post(createComment);
 router.route('/review').post(createReview);

--- a/src/routes/week.ts
+++ b/src/routes/week.ts
@@ -19,5 +19,4 @@ router
   .delete(restrict('admin'), deleteWeek);
 router.route('/current').post(currentWeek);
 
-
 export default router;


### PR DESCRIPTION
The changes here include:

1. Register users directly: to be used while testing the app, will be removed in the future
2. Solves issue with refresh token: the new access token generated from the refresh token route were missing the user role, this was causing the app to break once the user had to refresh their access token
3. Completes the relationship between User-Cohort: new users are now also saved to the corresponding Cohort document

There are also some changes to fix linting warnings