### PR TITLE
Week index

### DIFF
--- a/src/controllers/cohort.ts
+++ b/src/controllers/cohort.ts
@@ -90,11 +90,12 @@ const createWeeks = (type: CohortSubject, startOfCohort: Date) => {
 
   const weeks = [];
 
-  for (let weekName of weekNames) {
+  for (let i = 0; i < weekNames.length; i++) {
     weeks.push({
-      name: weekName,
+      name: weekNames[i],
       start: new Date(startTimestamp),
       end: new Date(startTimestamp + 7 * 24 * 60 * 60 * 1000 - 1000),
+      index: i,
     });
     startTimestamp += 7 * 24 * 60 * 60 * 1000;
   }

--- a/src/controllers/week.ts
+++ b/src/controllers/week.ts
@@ -53,6 +53,24 @@ const getWeek = async (req: Request, res: Response) => {
     .json({ status: 'Success', populatedWeek: cohort.weeks[weekIndex] });
 };
 
+const getWeekByIndex = async (req: Request, res: Response) => {
+  const { cohortId, index } = req.params;
+
+  const cohort = await Cohort.findById(cohortId);
+  if (!cohort) {
+    throw new BadRequestError('Cohort not found');
+  }
+
+  const i = parseInt(index);
+  if (isNaN(i) || !cohort.weeks[i]) {
+    throw new BadRequestError('Invalid week index');
+  }
+
+  await cohort.populate({ path: `weeks.${i}.sessions` });
+
+  res.status(200).json({ populatedWeek: cohort.weeks[i] });
+};
+
 const updateWeek = async (req: Request, res: Response) => {
   const { cohortId, weekId } = req.params;
 
@@ -119,4 +137,12 @@ const currentWeek = async (req: Request, res: Response) => {
   res.status(200).json({ currentWeek: cohort.weeks[weekIndex] });
 };
 
-export { getAllWeek, getWeek, updateWeek, deleteWeek, createWeek, currentWeek };
+export {
+  getAllWeek,
+  getWeek,
+  getWeekByIndex,
+  updateWeek,
+  deleteWeek,
+  createWeek,
+  currentWeek,
+};

--- a/src/models/Week.ts
+++ b/src/models/Week.ts
@@ -4,6 +4,7 @@ export interface IWeek extends Document {
   name: string;
   start: Date;
   end: Date;
+  index: number;
   sessions: Array<Types.ObjectId>;
 }
 
@@ -19,6 +20,9 @@ export const WeekSchema = new mongoose.Schema<IWeek>(
     },
     end: {
       type: Date,
+    },
+    index: {
+      type: Number,
     },
     sessions: [
       {

--- a/src/routes/week.ts
+++ b/src/routes/week.ts
@@ -5,6 +5,7 @@ import {
   deleteWeek,
   createWeek,
   currentWeek,
+  getWeekByIndex,
 } from '../controllers/week';
 import express from 'express';
 import restrict from '../middleware/authorizeRole';
@@ -19,5 +20,6 @@ router
   .get(getWeek)
   .patch(restrict('admin'), updateWeek)
   .delete(restrict('admin'), deleteWeek);
+router.route('/:cohortId/index/:index').get(getWeekByIndex);
 
 export default router;


### PR DESCRIPTION
Adds an index to each week document, this will be used in the front-end to navigate to the next/previous week.

This assumes that the weeks will not be deleted from a cohort (because indices are not updated if a week is removed), which I believe makes sense for the conditions of the MVP.