### PR TITLE
Deleting a session also removes if from the cohort

### DIFF
--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -27,7 +27,9 @@ router
 router
   .route('/:sessionId')
   .get(getSession)
-  .patch(restrict('mentor', 'student-leader'), updateSession)
+  .patch(restrict('mentor', 'student-leader'), updateSession);
+router
+  .route('/:cohortId/:sessionId')
   .delete(restrict('mentor', 'student-leader'), deleteSession);
 router
   .route('/:sessionId/student/updateStatus')


### PR DESCRIPTION
The current `deleteSession` method of the session controller only removes the session itself. We also need to remove that session's ObjectId inside of the Cohort document.