### PR TITLE
Avoids controller error

### DIFF
--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -255,9 +255,9 @@ const getStatus = async (req: Request, res: Response) => {
     return userId === req.user.userId;
   });
   if (!participantWithUserStatus) {
-    res.status(200).json(false);
+    return res.status(200).json(false);
   }
-  res.status(200).json(true);
+  return res.status(200).json(true);
 };
 
 const getUpcomingSessions = async (req: Request, res: Response) => {


### PR DESCRIPTION
The `getStatus` method was missing a return statement, which caused the endpoint to fail. This change fixes it.