### PR TITLE
Refactor create sessions

### DIFF
--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -42,8 +42,9 @@ const createSession = async (req: Request, res: Response) => {
       creator: userId,
     });
     await addSession(cohort, startDate, session);
-    return res.status(201).json({ session });
+    return res.status(201).json({ sessions: [session] });
   } else {
+    const newSessions = [];
     while (startTimestamp < cohortEnd) {
       const session = await SessionModel.create({
         start: new Date(startTimestamp),
@@ -55,11 +56,11 @@ const createSession = async (req: Request, res: Response) => {
       startTimestamp += weekInMil;
       endTimestamp += weekInMil;
 
-      console.log(session);
+      newSessions.push(session);
       const newStart = new Date(session?.start);
       await addSession(cohort, newStart, session);
     }
-    return res.status(201).json({ cohort });
+    return res.status(201).json({ sessions: newSessions });
   }
 };
 

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -266,9 +266,7 @@ const getUpcomingSessions = async (req: Request, res: Response) => {
   const sessions = await SessionModel.find({
     creator: userId,
     start: { $gte: Date.now() },
-  })
-    .limit(6)
-    .sort({ start: 'asc' });
+  }).sort({ start: 'asc' });
 
   res.status(200).json({ sessions });
 };

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -278,9 +278,7 @@ const getStudentUpcomingSessions = async (req: Request, res: Response) => {
   const sessions = await SessionModel.find({
     participant: userId,
     start: { $gte: Date.now() },
-  })
-    .limit(6)
-    .sort({ start: 'asc' });
+  }).sort({ start: 'asc' });
 
   res.status(200).json({ sessions });
 };


### PR DESCRIPTION
Changes the `createSession` method, to always return an array with the created sessions. This change simplifies how the response in handled in the front-end.

Removes the limit of upcoming sessions, now that the sessions are displayed using a dataGrid.